### PR TITLE
Fix: invalid catkin command for coverage test in tutorial

### DIFF
--- a/doc/tests/tests_tutorial.rst
+++ b/doc/tests/tests_tutorial.rst
@@ -76,7 +76,7 @@ and run the special `_coverage` target::
   sudo apt install ros-noetic-code-coverage
   catkin config --cmake-args -DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
   catkin build
-  catkin build moveit_core -v --no-deps --catkin-make-args moveit_core_coverage
+  catkin test moveit_core -v --no-deps --catkin-make-args moveit_core_coverage
 
 The output will print where the coverage report is located and it looks similar to the following image:
 


### PR DESCRIPTION
### Description

The `catkin` command in the tutorial used `build` instead of `test` to start a coverage test.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
